### PR TITLE
ENH updated alternative forecaster with cython

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 
 .slurm-logs/
 .snakemake/
+.snakemake*
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -97,6 +97,24 @@ Use the project's included YAML file to specify all packages needed: [semimarkov
 conda env create -f semimarkov_forecaster.yml
 ```
 
+#### 4. Setup the Cython extensions (optional)
+
+```
+$ cd covid19-forecasting/
+$ python setup.py # builds the Cython extensions!
+
+# python semimarkov_forecaster/simulate_traj__python.py \
+    --params_json_file workflows/example_simple/params.json \
+    --func_name python \
+    --n_trials 10000
+```
+
+* Expected output *
+
+```
+Finished 10000 trials after     0.062 sec
+```
+
 
 # Modeling
 

--- a/semimarkov_forecaster/simulate_traj__cython.pyx
+++ b/semimarkov_forecaster/simulate_traj__cython.pyx
@@ -1,0 +1,54 @@
+import argparse
+import json
+import os
+import sys
+import numpy as np
+import itertools
+
+def simulate_traj__cython(
+        int start_stage,
+        double[:] pRecover_K,
+        double[:,:,:] duration_cdf_HKT,
+        int[:] stage_ids_L,
+        int[:] health_ids_L,
+        int[:] durations_L,
+        double[:] rand_vals_M,
+        ):
+    """ Faster cython version to simulate trajectory
+
+    Returns
+    -------
+    """
+    cdef int MAX_STAGE = pRecover_K.shape[0]
+    cdef int Dmax = duration_cdf_HKT.shape[2]
+    cdef int stage = start_stage
+    cdef int health = 0
+
+    cdef int mm = 0
+    cdef int ll = 0
+    cdef int d = 0
+    cdef int is_terminal = 0
+    while (0 <= stage) and (stage < MAX_STAGE):
+        if health == 0:
+            health = rand_vals_M[mm] < pRecover_K[stage]
+            mm += 1
+
+        for d in range(1, Dmax):
+            if rand_vals_M[mm] < duration_cdf_HKT[health, stage, d-1]:
+                break
+        mm += 1
+
+        durations_L[ll] = d
+        stage_ids_L[ll] = stage
+        health_ids_L[ll] = health
+        ll += 1
+
+        if health > 0:
+            stage -= 1
+        else:
+            stage += 1
+        if stage >= MAX_STAGE:
+            is_terminal = 1
+            break
+
+    return (mm, ll, is_terminal)

--- a/semimarkov_forecaster/simulate_traj__python.py
+++ b/semimarkov_forecaster/simulate_traj__python.py
@@ -1,0 +1,129 @@
+import argparse
+import json
+import os
+import sys
+import numpy as np
+import itertools
+import time
+from simulate_traj__cython import simulate_traj__cython
+
+def simulate_traj__python(
+        start_stage,
+        pRecover_K,
+        duration_cdf_HKT,
+        stage_ids_L,
+        health_ids_L,
+        durations_L,
+        rand_vals_M,
+        ):
+    ''' Simulate trajectory of a patient, using pure python numpy code
+
+    Returns
+    -------
+    mm : int
+        Number of random values used
+    stage_ids_L : 1D array, shape (L,)
+    health_ids_L : 1D array, shape (L,)
+    durations_L : 1D array, shape (L,)
+    '''
+    MAX_STAGE = pRecover_K.size
+    Dmax = duration_cdf_HKT.shape[2]
+
+    stage = start_stage
+    health = 0
+    mm = 0
+    ll = 0
+    while (0 <= stage) and (stage < MAX_STAGE):
+        if health == 0:
+            health = int(rand_vals_M[mm] < pRecover_K[stage])
+            mm += 1
+
+        for d in range(1, Dmax):
+            if rand_vals_M[mm] < duration_cdf_HKT[health, stage, d - 1]:
+                break
+        mm += 1
+
+        durations_L[ll] = d
+        stage_ids_L[ll] = stage
+        health_ids_L[ll] = health
+        ll += 1
+
+        if health > 0:
+            stage -= 1
+        else:
+            stage += 1
+        if stage >= MAX_STAGE:
+            health = -1
+            break
+            
+    return (mm, ll, int(health < 0), stage_ids_L, health_ids_L, durations_L)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--seed', default=1001, type=int)
+    parser.add_argument('--n_trials', default=3, type=int)
+    parser.add_argument('--func_name', default='python', type=str)
+    parser.add_argument('--params_json_file', default=None)
+    args = parser.parse_args()
+
+    with open(args.params_json_file, 'r') as f:
+        config_dict = json.load(f)
+
+    stage_names = ['InGeneralWard', 'OffVentInICU', 'OnVentInICU']
+    health_ids = [0, 1]
+
+    HEALTH_STATE_ID_TO_NAME = {0: 'Declining', 1: 'Recovering'}
+
+    H = len(health_ids)
+    K = len(stage_names)
+
+    Tmax = 25
+    duration_cdf_HKT = np.zeros((H, K, Tmax))
+    for health, stage in itertools.product(health_ids, np.arange(K)):
+        choices_and_probas_dict = config_dict[
+            'pmf_duration_%s_%s' % (
+                HEALTH_STATE_ID_TO_NAME[health], stage_names[stage])]
+        choices = np.fromiter(choices_and_probas_dict.keys(), dtype=np.int32)
+        probas = np.fromiter(choices_and_probas_dict.values(), dtype=np.float64)
+        for c, p in zip(choices, probas):
+            assert c >= 1
+            duration_cdf_HKT[health, stage, c - 1] = p
+        duration_cdf_HKT[health, stage, :] = np.cumsum(duration_cdf_HKT[health, stage, :])
+
+    sim_kwargs = dict(
+        start_stage=0)
+    sim_kwargs['duration_cdf_HKT'] = duration_cdf_HKT
+    sim_kwargs['pRecover_K'] = np.asarray([
+        float(config_dict['proba_Recovering_given_%s' % stage])
+        for stage in stage_names])
+
+    L = K * 2
+    M = L * 2 + 1
+
+    prng = np.random.RandomState(args.seed)
+
+    start_time_sec = time.time()
+    for trial in range(args.n_trials):
+        # Draw all possible random values needed in advance
+        rand_vals_M = prng.rand(M)
+
+        if trial == 0:
+            sim_kwargs['durations_L'] = np.zeros(L, dtype=np.int32)
+            sim_kwargs['stage_ids_L'] = -99 * np.ones(L, dtype=np.int32)
+            sim_kwargs['health_ids_L'] = -99 * np.ones(L, dtype=np.int32)
+        else:
+            sim_kwargs['durations_L'][:] = 0
+            sim_kwargs['stage_ids_L'][:] = -99
+            sim_kwargs['health_ids_L'][:] = -99
+
+        if args.func_name.count("cython"):
+            mm, curL, is_terminal = simulate_traj__cython(rand_vals_M=rand_vals_M, **sim_kwargs)
+        else:
+            mm, curL, is_terminal, _, _, _ = simulate_traj__python(rand_vals_M=rand_vals_M, **sim_kwargs)
+
+        #print(is_terminal, sim_kwargs['durations_L'][:curL], sim_kwargs['stage_ids_L'][:curL])
+    elapsed_time_sec = time.time() - start_time_sec
+    print("Finished %d trials after %9.3f sec" % (args.n_trials, elapsed_time_sec))
+    print("Last sim durations: " + str(sim_kwargs['durations_L']))
+        

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,11 @@
+# Build Cython extensions to run fast
+
+from distutils.core import setup
+from Cython.Build import cythonize
+
+setup(
+        ext_modules=cythonize('semimarkov_forecaster/simulate_traj__cython.pyx', build_dir="build"),
+	script_args=['build_ext'],
+	#prefix="./",
+	#install_base="./",
+	options={"build_ext": {"inplace": True}})

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
-# Build Cython extensions to run fast
+''' Script to build the Cython extensions
+'''
 
 from distutils.core import setup
 from Cython.Build import cythonize
@@ -6,6 +7,4 @@ from Cython.Build import cythonize
 setup(
         ext_modules=cythonize('semimarkov_forecaster/simulate_traj__cython.pyx', build_dir="build"),
 	script_args=['build_ext'],
-	#prefix="./",
-	#install_base="./",
 	options={"build_ext": {"inplace": True}})


### PR DESCRIPTION
# Overview

Basically, there is now a much faster pure-Python version, as well as a even-faster-than-that Cython version.

The pure python version avoids creating a PatientTrajectory object, and just does the simulation directly, writing to some provided preallocated arrays (so no memory is allocated on the fly)

See new script:  [simulate_traj__python.py](https://github.com/tufts-ml/covid19-forecasting/blob/mch-cythonize/semimarkov_forecaster/simulate_traj__python.py)

The cython version just does the same thing, but in C

See new script: [simulate_traj__cython.pyx](https://github.com/tufts-ml/covid19-forecasting/blob/mch-cythonize/semimarkov_forecaster/simulate_traj__cython.pyx)

# background

If you want more info about how to Cython something, see

http://nealhughes.net/cython1/

(No relation to me!)

# Installation

Build the cython extension with

```
$ cd covid19-forecasting/
$ python setup.py build_ext --inplace
```

# Usage

### Try 100k patients with simple python-only script :  0.8 sec

```
$ python semimarkov_forecaster/simulate_traj__python.py --params_json_file workflows/example_simple/params.json --func_name python --n_trials 100000
Finished 100000 trials after     0.806 sec
Last sim durations: [3 4 1 0 0 0]
```
### Try same 100k patients with Cython : 0.6 sec 🚀 💯 

```
$ python semimarkov_forecaster/simulate_traj__python.py --params_json_file workflows/example_simple/params.json --func_name cython --n_trials 100000
Finished 100000 trials after     0.617 sec
Last sim durations: [3 4 1 0 0 0]
```
The last line verifies the *same output* was produced by this simulation.